### PR TITLE
Correct typo

### DIFF
--- a/cuckoo/web/src/scss/_variables.scss
+++ b/cuckoo/web/src/scss/_variables.scss
@@ -46,7 +46,7 @@ $night_accent_color: #555;
 $night_darker_color: #131313;
 
 $night_table_even_color: #2d2d2d;
-$nigh_table_odd_color: #313131;
+$night_table_odd_color: #313131;
 
 // headstart on the dynamic cuckoo color library: badges
 $badge-colors: (


### PR DESCRIPTION
The variable $night_table_odd_color has a typo